### PR TITLE
Add auto mode for indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Your login is fetched from the environnement: `$USER`. You can override this in 
 
 For your name, it is fetched from your `finger` information (_Full name_ field). You can change this information in your DE configuration manager or in cli with [`chfn`](http://linux.die.net/man/1/chfn). As for the login you can override this value in your `.vimrc` with `let g:epi_name = 'Nils Logi'`.
 
+## Indentation
+
+You can use the same indentation as emacs do by using `let g:epitech_mode_emacs = 1` in your `.vimrc`. Alternatively you can have emacs indentation only for Epitech's files (having a valid header) with `let g:epitech_mode_auto = 1`.
+
 ## Checker
 
 You can call the checker with the command `:EpiNormeCheck`.

--- a/after/ftplugin/c.vim
+++ b/after/ftplugin/c.vim
@@ -1,14 +1,19 @@
 filetype plugin indent on
 
-setlocal cindent
 setlocal colorcolumn=80
 setlocal comments=s:/*,m:**,ex:*/
-setlocal cinoptions={1s,>2s,e-1s,^-1s,n-1s,:1s,p5,i4,(0,u0,W1s
 setlocal list
 setlocal listchars=tab:··
 setlocal noexpandtab
 setlocal shiftwidth=2
 setlocal softtabstop=8
 setlocal tabstop=8
+
+setlocal cindent
+if get(g:, "epitech_mode_emacs")
+    setlocal cinoptions={1s,>2s,e-1s,^-1s,n-1s,:1s,p5,i4,(0,u0,W1s
+else
+    setlocal cinoptions=
+endif
 
 let c_space_errors = 1

--- a/after/ftplugin/c.vim
+++ b/after/ftplugin/c.vim
@@ -10,7 +10,7 @@ setlocal softtabstop=8
 setlocal tabstop=8
 
 setlocal cindent
-if get(g:, "epitech_mode_emacs")
+if get(g:, "epitech_mode_emacs") || (get(g:, "epitech_mode_auto") && epitech#header#IsPresent())
     setlocal cinoptions={1s,>2s,e-1s,^-1s,n-1s,:1s,p5,i4,(0,u0,W1s
 else
     setlocal cinoptions=

--- a/autoload/epitech/header.vim
+++ b/autoload/epitech/header.vim
@@ -4,11 +4,6 @@ let s:comMap = {
             \ 'make': {'b': '##', 'm': '##', 'e': '##'},
             \}
 
-function! s:HasHeader()
-    let l:val = search('^.\{2} Last update ', 'cnw')
-    return l:val > 0 && l:val < 10
-endfunction
-
 function! s:InsertFirst()
     call inputsave()
     let proj_name = input('Enter project name: ')
@@ -27,8 +22,13 @@ function! s:IsSupportedFt()
     return has_key(s:comMap, &filetype)
 endfunction
 
+function! epitech#header#IsPresent()
+    let l:val = search('^.\{2} Last update ', 'cnw')
+    return l:val > 0 && l:val < 10
+endfunction
+
 function! epitech#header#Put()
-    if s:HasHeader() > 0
+    if epitech#header#IsPresent() > 0
         return
     endif
 
@@ -60,7 +60,7 @@ function! epitech#header#Update()
         return
     endif
 
-    if s:HasHeader() > 0
+    if epitech#header#IsPresent() > 0
         let save_cursor = getpos(".")
         1,10s/\(.*\) Last update .*/\1 Last update µLASTUPDATEµ µLOGINLASTµ/ge
         1,10s/µLOGINLASTµ/\= g:epi_name/ge


### PR DESCRIPTION
A lot of people still use the utterly ugly emacs way to indent for some reason. To soften group work you can now use 2 options:
- Normal mode: use a norme compliant indentation
- Emacs mode: use emacs indentation for all files
- Auto mode: use emacs indentation only for files with a valid header

The way to configure this behaviour as been documented in the README.
